### PR TITLE
[LLD][MinGW] Support machine:arm64x when invoked in MinGW mode.

### DIFF
--- a/lld/Common/DriverDispatcher.cpp
+++ b/lld/Common/DriverDispatcher.cpp
@@ -45,7 +45,7 @@ static cl::TokenizerCallback getDefaultQuotingStyle() {
 
 static bool isPETargetName(StringRef s) {
   return s == "i386pe" || s == "i386pep" || s == "thumb2pe" || s == "arm64pe" ||
-         s == "arm64ecpe";
+         s == "arm64ecpe" || s == "arm64xpe";
 }
 
 static std::optional<bool> isPETarget(llvm::ArrayRef<const char *> args) {

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -448,6 +448,8 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       add("-machine:arm64");
     else if (s == "arm64ecpe")
       add("-machine:arm64ec");
+    else if (s == "arm64xpe")
+      add("-machine:arm64x");
     else
       error("unknown parameter: -m" + s);
   }

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -31,6 +31,12 @@ ARM64EC-SAME: -machine:arm64ec
 ARM64EC-SAME: -alternatename:__image_base__=__ImageBase
 ARM64EC-SAME: foo.o
 
+RUN: ld.lld -### foo.o -m arm64xpe 2>&1 | FileCheck -check-prefix=ARM64X %s
+ARM64X:      -out:a.exe
+ARM64X-SAME: -machine:arm64x
+ARM64X-SAME: -alternatename:__image_base__=__ImageBase
+ARM64X-SAME: foo.o
+
 RUN: ld.lld -### foo.o -m i386pep -shared 2>&1 | FileCheck -check-prefix=SHARED %s
 RUN: ld.lld -### foo.o -m i386pep --shared 2>&1 | FileCheck -check-prefix=SHARED %s
 RUN: ld.lld -### foo.o -m i386pep --dll 2>&1 | FileCheck -check-prefix=SHARED %s


### PR DESCRIPTION
Mingw mode already supports building machine:arm64ec arm64x binaries, support machine:arm64x ones too.